### PR TITLE
#2 - aligning tiles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "nesbot/carbon": "^2.63"
   },
   "require-dev": {
-    "blumilksoftware/codestyle": "^1.9",
+    "blumilksoftware/codestyle": "^1.10",
     "phpunit/phpunit": "^9.5"
   },
   "authors": [

--- a/src/Decorators/OpacityDecorator.php
+++ b/src/Decorators/OpacityDecorator.php
@@ -21,17 +21,21 @@ class OpacityDecorator implements Decorator
         foreach ($bucket as $tile) {
             $tile->description = match (true) {
                 $tile->count === 0 => "background: White",
-                $tile->count === $max => "background: {$this->color}; opacity: .9",
-                $tile->count >= $max * .9 => "background: {$this->color}; opacity: .8",
-                $tile->count >= $max * .8 => "background: {$this->color}; opacity: .7",
-                $tile->count >= $max * .7 => "background: {$this->color}; opacity: .6",
-                $tile->count >= $max * .6 => "background: {$this->color}; opacity: .5",
-                $tile->count >= $max * .5 => "background: {$this->color}; opacity: .4",
-                $tile->count >= $max * .4 => "background: {$this->color}; opacity: .3",
-                $tile->count >= $max * .3 => "background: {$this->color}; opacity: .2",
-                $tile->count >= $max * .2 => "background: {$this->color}; opacity: .1",
-                default => "background: {$this->color}; opacity: .05",
+                $tile->count === $max => "background: {$this->color}; opacity: .9;",
+                $tile->count >= $max * .9 => "background: {$this->color}; opacity: .8;",
+                $tile->count >= $max * .8 => "background: {$this->color}; opacity: .7;",
+                $tile->count >= $max * .7 => "background: {$this->color}; opacity: .6;",
+                $tile->count >= $max * .6 => "background: {$this->color}; opacity: .5;",
+                $tile->count >= $max * .5 => "background: {$this->color}; opacity: .4;",
+                $tile->count >= $max * .4 => "background: {$this->color}; opacity: .3;",
+                $tile->count >= $max * .3 => "background: {$this->color}; opacity: .2;",
+                $tile->count >= $max * .2 => "background: {$this->color}; opacity: .1;",
+                default => "background: {$this->color}; opacity: .05;",
             };
+
+            if ($tile->inFuture) {
+                $tile->description = " opacity: .25;";
+            }
         }
 
         return $bucket;

--- a/src/Decorators/TailwindDecorator.php
+++ b/src/Decorators/TailwindDecorator.php
@@ -32,6 +32,10 @@ class TailwindDecorator implements Decorator
                 $tile->count >= $max * .2 => "bg-{$this->theme}-100",
                 default => "bg-{$this->theme}-50",
             };
+
+            if ($tile->inFuture) {
+                $tile->description = " opacity-25";
+            }
         }
 
         return $bucket;

--- a/src/Tile.php
+++ b/src/Tile.php
@@ -12,6 +12,7 @@ class Tile implements JsonSerializable
         public readonly string $label,
         public readonly int $count,
         public string $description = "",
+        public bool $inFuture = false,
     ) {}
 
     public function jsonSerialize(): array

--- a/tests/PeriodAligningTest.php
+++ b/tests/PeriodAligningTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Blumilk\HeatmapBuilder\HeatmapBuilder;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class PeriodAligningTest extends TestCase
+{
+    public function testAligningPeriodForDailyHeatmap(): void
+    {
+        $builder = new HeatmapBuilder(now: Carbon::parse("2022-11-19 00:00:00"));
+        $builder->forLastMonth()->alignedToStartOfPeriod();
+
+        $result = $builder->build($this->getData());
+
+        $this->assertSameSize(
+            expected: range(0, 33),
+            actual: $result,
+        );
+    }
+
+    public function testAligningPeriodForDailyHeatmapFromBothSides(): void
+    {
+        $builder = new HeatmapBuilder(now: Carbon::parse("2022-11-19 00:00:00"));
+        $builder->forLastMonth()->alignedToStartOfPeriod()->alignedToEndOfPeriod();
+
+        $result = $builder->build($this->getData());
+
+        $this->assertSameSize(
+            expected: range(0, 34),
+            actual: $result,
+        );
+    }
+
+    public function testAligningPeriodForNumberOfTiles(): void
+    {
+        $builder = new HeatmapBuilder(now: Carbon::parse("2022-11-19 00:00:00"));
+        $builder->forNumberOfTiles(4)->alignedToStartOfPeriod();
+
+        $result = $builder->build($this->getData());
+
+        $this->assertSameSize(
+            expected: range(0, 5),
+            actual: $result,
+        );
+    }
+
+    protected function getData(): array
+    {
+        return [
+            ["created_at" => "2022-11-01 00:00:00"],
+            ["created_at" => "2022-11-03 00:00:00"],
+            ["created_at" => "2022-11-16 00:00:00"],
+            ["created_at" => "2022-11-16 00:00:00"],
+            ["created_at" => "2022-11-18 00:00:00"],
+            ["created_at" => "2022-11-19 00:00:00"],
+        ];
+    }
+}


### PR DESCRIPTION
Default behaviour for this code:
```php
$builder = new HeatmapBuilder(
    now: Carbon::now(),
    decorator: new TailwindDecorator("blue"),
);
$result = $builder
    ->forLastMonth()
    ->build([
        ["created_at" => "2022-12-24 18:00:00"],
        ["created_at" => "2022-12-24 18:00:00"],
        ["created_at" => "2022-12-24 18:00:00"],
        ["created_at" => "2022-12-25 18:00:00"],
    ]);
```
would be a heatmap like this:
![obraz](https://user-images.githubusercontent.com/10898728/211165063-17819840-cd33-43ac-9a4b-d87537ba48e9.png)

We would like to start with Monday and fill "future" tiles, so this:
```php
$result = $builder
    ->alignedToStartOfPeriod()
    ->alignedToEndOfPeriod()
```
should solve the problem:

![obraz](https://user-images.githubusercontent.com/10898728/211165046-12ce4dec-a125-4a49-a86e-716ab0eb442c.png)

This should close #2.